### PR TITLE
Fix Home Manager warnings after flake update

### DIFF
--- a/home/apps/gitconfig/default.nix
+++ b/home/apps/gitconfig/default.nix
@@ -17,12 +17,11 @@
 
   programs.git = {
     enable = true;
-    userName = "Femi Agbabiaka";
-    userEmail = "femi@femiagbabiaka.xyz";
-    delta = {
-      enable = true;
-    };
-    extraConfig = {
+    settings = {
+      user = {
+        name = "Femi Agbabiaka";
+        email = "femi@femiagbabiaka.xyz";
+      };
       core = {
         editor = "hx";
         excludesFile = "~/.gitignore";
@@ -31,10 +30,10 @@
         user = "femiagbabiaka";
       };
       push = {
-        autoSetupRemote = "true";
+        autoSetupRemote = true;
       };
       pull = {
-        rebase = "true";
+        rebase = true;
       };
       url = {
         "git@github.com:fastly" = {
@@ -43,4 +42,9 @@
       };
     };
   };
-}
+
+  programs.delta = {
+    enable = true;
+    enableGitIntegration = true;
+  };
+};

--- a/home/apps/neovim/default.nix
+++ b/home/apps/neovim/default.nix
@@ -9,7 +9,7 @@ let
   nvimConfig = pkgs.writeText "init.lua" initLua;
   neovimWrapper = pkgs.symlinkJoin {
     name = "neovim-for-femi";
-    paths = [ neovim-nightly-overlay.packages.${pkgs.system}.default ];
+    paths = [ neovim-nightly-overlay.packages.${pkgs.stdenv.hostPlatform.system}.default ];
     buildInputs = [ pkgs.makeWrapper ];
 
     postBuild = ''


### PR DESCRIPTION
## Summary
- migrate the git Home Manager module to the new `programs.git.settings` structure
- manage delta through the standalone `programs.delta` module with explicit Git integration
- update the Neovim wrapper to use `pkgs.stdenv.hostPlatform.system` for overlay selection

## Testing
- not run (nix is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_690a4a5fdb0483218830115ed5b92553