### PR TITLE
Fix radicle-httpd tailscale permission issue

### DIFF
--- a/systems/cerebro/configuration.nix
+++ b/systems/cerebro/configuration.nix
@@ -87,6 +87,7 @@
   users.users.radicle = {
     isSystemUser = true;
     group = "radicle";
+    extraGroups = [ "tailscale" ];
     home = "/var/lib/radicle-seed";
     createHome = true;
   };


### PR DESCRIPTION
## Summary
- add the radicle system user to the `tailscale` group so its service can query `tailscale ip`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cf32ce1148321aee1e5af87b09350)